### PR TITLE
Split screen support

### DIFF
--- a/4PlayerCoop/MPScriptLoad.cs
+++ b/4PlayerCoop/MPScriptLoad.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System.Reflection;
+using UnityEngine;
+using UnityEngine.UI;
 
 namespace MPLimitRemover
 {
@@ -12,11 +14,14 @@ namespace MPLimitRemover
 
         public void Patch()
         {
+            //Put in patched methods here
             //On.StoreManager.OnGameLobbyJoinRequested += new On.StoreManager.hook_OnGameLobbyJoinRequested(GameLobbyJoinRequest);
             On.ConnectPhotonMaster.CreateOrJoin += new On.ConnectPhotonMaster.hook_CreateOrJoin(CreateJoinRoom);
             On.ConnectPhotonMaster.CreateRoom_1 += new On.ConnectPhotonMaster.hook_CreateRoom_1(CreateStoreRoom);
             On.OtherPlayersCompass.Update += new On.OtherPlayersCompass.hook_Update(CompassUpdate);
-            //Put in patched methods here
+            On.PauseMenu.Show += new On.PauseMenu.hook_Show(ShowPatch);
+            On.PauseMenu.Update += new On.PauseMenu.hook_Update(UpdatePatch);
+            
         }
 
         public void CreateJoinRoom(On.ConnectPhotonMaster.orig_CreateOrJoin original, ConnectPhotonMaster self, string _roomName)
@@ -58,6 +63,41 @@ namespace MPLimitRemover
             timer -= Time.deltaTime;
             if (timer <= 0f)
                 Debug.Log(Global.Lobby.PlayersInLobby.Count);
+        }
+
+        public static void ShowPatch(On.PauseMenu.orig_Show original, PauseMenu instance)
+        {
+            original(instance);
+            Button onlineButton = typeof(PauseMenu).GetField("m_btnToggleNetwork", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(instance) as Button;
+
+            //Due to spawning bugs, only allow disconnect if you are the master, or if you are a client with no splitscreen, force splitscreen to quit before disconnect
+            if (PhotonNetwork.isMasterClient || SplitScreenManager.Instance.LocalPlayerCount == 1)
+            {
+                onlineButton.interactable = true;
+            }
+
+            SetSplitButtonInteractable(instance);
+
+            //If this is used with a second splitscreen player both players load in missing inventory. Very BAD. Disabled for now.
+            //Button findMatchButton = typeof(PauseMenu).GetField("m_btnFindMatch", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(instance) as Button;
+            //findMatchButton.interactable = PhotonNetwork.offlineMode;
+        }
+
+        //for some reason the update function also forces the split button interactable, so we have to override it here too
+        public static void UpdatePatch(On.PauseMenu.orig_Update orignal, PauseMenu instance)
+        {
+            orignal(instance);
+            SetSplitButtonInteractable(instance);
+        }
+
+        public static void SetSplitButtonInteractable(PauseMenu instance)
+        {
+            //Debug.Log("isMasterClient: " + PhotonNetwork.isMasterClient);
+            Button splitButton = typeof(PauseMenu).GetField("m_btnSplit", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(instance) as Button;
+            if (!PhotonNetwork.isMasterClient || !PhotonNetwork.isNonMasterClientInRoom)
+            {
+                splitButton.interactable = true;
+            }
         }
     }
 }

--- a/4PlayerCoop/PlayerLimitRemover.cs
+++ b/4PlayerCoop/PlayerLimitRemover.cs
@@ -12,9 +12,9 @@ namespace MPLimitRemover
 
         public PlayerLimitRemover()
         {
-            this.ModID = "Fae's Player Limit Remover";
-            this.Version = "0100";
-            this.author = "Faedar";
+            this.ModID = "Player Limit Remover";
+            this.Version = "0110";
+            this.author = "Faedar, Ashnal";
         }
 
         public static MPScriptLoad limitRemover;


### PR DESCRIPTION
Added code to allow usage of the split screen menu button and the start/stop online button. With light testing, allows a player to start an online session with a splitscreen partner active. Also allows a splitscreen partner to join a player that is already connected to an online lobby.

Find game is not allowed for an active split screen session as it resulted in both characters losing almost all of their inventory on joining. Disconnecting from an online session with a  splitscreen partner active is not allowed due to a spawning bug that spawns the splitscreen player at the last place the main player entered that zone, and not by the side of the main player.

Ideal usage is host and splitscreen player open game to friends, remote player joins alone, then remote splitscreen player joins. Ideal is also that remote splitscreen player disconnects before the main remote player does.